### PR TITLE
zy - Added Menu Item Create for frontend and tests

### DIFF
--- a/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.js
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.js
@@ -22,7 +22,7 @@ export default function UCSBDiningCommonsMenuItemTable({
     const deleteMutation = useBackendMutation(
         cellToAxiosParamsDelete,
         { onSuccess: onDeleteSuccess },
-        ["/api/ucsbDiningCommonsMenuItem/all"]
+        ["/api/UCSBDiningCommonsMenuItem/all"]
     );
     // Stryker restore all 
 

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.js
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.js
@@ -1,12 +1,47 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemCreatePage() {
+export default function UCSBDiningCommonsMenuItemCreatePage({storybook=false}) {
 
-  // Stryker disable all : placeholder for future implementation
+  const objectToAxiosParams = (ucsbDiningCommonsMenuItem) => ({
+    url: "/api/UCSBDiningCommonsMenuItem/post",
+    method: "POST",
+    params: {
+     diningCommonsCode: ucsbDiningCommonsMenuItem.diningCommonsCode,
+     name: ucsbDiningCommonsMenuItem.name,
+     station: ucsbDiningCommonsMenuItem.station
+    }
+  });
+
+  const onSuccess = (ucsbDiningCommonsMenuItem) => {
+    toast(`New UCSBDiningCommonsMenuItem Created - id: ${ucsbDiningCommonsMenuItem.id} diningCommonsCode: ${ucsbDiningCommonsMenuItem.diningCommonsCode} name: ${ucsbDiningCommonsMenuItem.name} station: ${ucsbDiningCommonsMenuItem.station}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/UCSBDiningCommonsMenuItem/all"] // mutation makes this key stale so that pages relying on it reload
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/diningcommonsmenuitem" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New UCSBDiningCommonsMenuItem</h1>
+        <UCSBDiningCommonsMenuItemForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/utils/UCSBDiningCommonsMenuItemUtils.js
+++ b/frontend/src/main/utils/UCSBDiningCommonsMenuItemUtils.js
@@ -7,7 +7,7 @@ export function onDeleteSuccess(message) {
 
 export function cellToAxiosParamsDelete(cell) {
     return {
-        url: "/api/ucsbDiningCommonsMenuItem",
+        url: "/api/UCSBDiningCommonsMenuItem",
         method: "DELETE",
         params: {
             id: cell.row.values.id

--- a/frontend/src/stories/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.stories.js
+++ b/frontend/src/stories/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.stories.js
@@ -36,7 +36,7 @@ ThreeItemsAdminUser.args = {
 
 ThreeItemsAdminUser.parameters = {
     msw: [
-        rest.delete('/api/ucsbDiningCommonsMenuItem', (req, res, ctx) => {
+        rest.delete('/api/UCSBDiningCommonsMenuItem', (req, res, ctx) => {
             window.alert("DELETE: " + JSON.stringify(req.url));
             return res(ctx.status(200),ctx.json({}));
         }),

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.stories.js
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.stories.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage"
+
+export default {
+    title: 'pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage',
+    component: UCSBDiningCommonsMenuItemCreatePage
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/UCSBDiningCommonsMenuItem/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}
+
+
+

--- a/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.test.js
+++ b/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.test.js
@@ -17,7 +17,7 @@ describe("UCSBDiningCommonsMenuItemTable tests", () => {
   const queryClient = new QueryClient();
 
   const expectedHeaders = ["id", "Dining Commons Code", "Name", "Station"];
-  const expectedFields = ["id", "dining commons code", "name", "station"];
+  const expectedFields = ["id", "diningCommonsCode", "name", "station"];
   const testId = "UCSBDiningCommonsMenuItemTable";
 
   test("renders empty table correctly", () => {

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem.test.js/UCSBDiningCommonsMenuItemCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem.test.js/UCSBDiningCommonsMenuItemCreatePage.test.js
@@ -1,31 +1,48 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
 
-    const setupUserOnly = () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+    });
 
     const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
-
-        setupUserOnly();
-       
-        // act
+    test("renders without crashing", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -33,11 +50,62 @@ describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
-
-        // assert
-        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
     });
 
+    test("on submit, makes request to backend, and redirects to /diningcommonsmenuitem", async () => {
+
+        const queryClient = new QueryClient();
+        const ucsbDiningCommonsMenuItem = {
+            id: 3,
+            diningCommonsCode: "ortega",
+            name: "Chicken Caesar Salad",
+            station: "Entrees"
+        };
+
+        axiosMock.onPost("/api/UCSBDiningCommonsMenuItem/post").reply(202, ucsbDiningCommonsMenuItem);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBDiningCommonsMenuItemCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByLabelText("Name")).toBeInTheDocument();
+        });
+
+        const diningCommonsCodeInput = screen.getByLabelText("Dining Commons Code");
+        expect(diningCommonsCodeInput).toBeInTheDocument();
+
+        const nameInput = screen.getByLabelText("Name");
+        expect(nameInput).toBeInTheDocument();
+
+        const stationInput = screen.getByLabelText("Station");
+        expect(stationInput).toBeInTheDocument();
+
+        const createButton = screen.getByText("Create");
+        expect(createButton).toBeInTheDocument();
+
+        fireEvent.change(diningCommonsCodeInput, { target: { value: 'ortega' } })
+        fireEvent.change(nameInput, { target: { value: 'Chicken Caesar Salad' } })
+        fireEvent.change(stationInput, { target: { value: 'Entrees' } })
+        fireEvent.click(createButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual({
+            diningCommonsCode: "ortega",
+            name: "Chicken Caesar Salad",
+            station: "Entrees"
+        });
+
+        // assert - check that the toast was called with the expected message
+        expect(mockToast).toBeCalledWith("New UCSBDiningCommonsMenuItem Created - id: 3 diningCommonsCode: ortega name: Chicken Caesar Salad station: Entrees");
+        expect(mockNavigate).toBeCalledWith({ "to": "/diningcommonsmenuitem" });
+
+    });
 });
 
 

--- a/frontend/src/tests/utils/UCSBDiningCommonsMenuItemUtils.test.js
+++ b/frontend/src/tests/utils/UCSBDiningCommonsMenuItemUtils.test.js
@@ -43,7 +43,7 @@ describe("UCSBDiningCommonsMenuItemUtils", () => {
 
             // assert
             expect(result).toEqual({
-                url: "/api/ucsbDiningCommonsMenuItem",
+                url: "/api/UCSBDiningCommonsMenuItem",
                 method: "DELETE",
                 params: { id: 17 }
             });


### PR DESCRIPTION
Added Menu Item Create for frontend and tests
Dokku deployment: https://team03-zhenyuyu1-dev.dokku-06.cs.ucsb.edu/
Storybook for PR: https://ucsb-cs156-f23.github.io/team03-f23-6pm-2/prs/83/storybook/?path=/story/components-nav-appnavbar--no-role

Steps to test the Create page:
1. Login to the dokku deployment page
2. Navigate to the "UCSB Dining Commons Menu Item" page and click on create.
3. Fill in the "Dining Commons Code", "Name", and "Station" fields. The "Dining Commons Code" and "Station" fields have a max of 100 characters limit.
4. Press the blue "Create" button after filling out the fields. A pop-up saying that a new UCSBDiningCommonsMenuItem has been created with the fields you entered should appear in the top right corner.
5. Navigate to Swagger to check if the new MenuItem was successfully created by making an API call to GET all entries in the database. You should see your entry that you made on the create page display.

On the Dokku page:
<img width="1423" alt="Screenshot 2023-11-09 at 2 23 25 PM" src="https://github.com/ucsb-cs156-f23/team03-f23-6pm-2/assets/68752665/29a0420e-11b4-45fe-947d-4bc790da23a7">
<img width="335" alt="Screenshot 2023-11-09 at 2 23 49 PM" src="https://github.com/ucsb-cs156-f23/team03-f23-6pm-2/assets/68752665/ae4ae7e8-9f69-489c-b271-94e89ace532b">

If the entry is invalid: 
<img width="1328" alt="Screenshot 2023-11-09 at 2 25 37 PM" src="https://github.com/ucsb-cs156-f23/team03-f23-6pm-2/assets/68752665/52d763fb-a854-469f-9fc0-4cc63d59f8ce">


On Swagger after creating the new database entry:
<img width="1384" alt="Screenshot 2023-11-09 at 2 24 24 PM" src="https://github.com/ucsb-cs156-f23/team03-f23-6pm-2/assets/68752665/bebae1cf-e300-4917-bcbe-a196077f429b">

Closes #13 